### PR TITLE
Add a weekly build to ensure project keeps working

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,9 @@
 name: CI
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * 6'
 
 env:
   CI: "ON"

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This project offers a ready to use integration of stdlib for CMake, including an
 Additionally, some boilerplate text in the README is available below as well as a testing setup with GitHub actions for GCC.
 The general CMake style should allow you to reuse most of the CMake build files *without* modification, just change the project name, add your source files and you are ready to go.
 
-You can [just *use this template* to create new project](https://github.com/awvwgk/stdlib-cmake-example/generate).
+You can [just *use this template* to create new project](https://github.com/fortran-lang/stdlib-cmake-example/generate).
 Remove this introduction from the README afterwards and fill in your project details.
 
 For more information on stdlib visit its [documentation](https://stdlib.fortran-lang.org).


### PR DESCRIPTION
Set weekly builds on weekends:

```yml
on:
  schedule:
    - cron: '0 0 * * 6'  # see https://crontab.guru/#0_0_*_*_6
```

Also fixes a link pointing to the pre-moved repo